### PR TITLE
Mor flexibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,11 +15,14 @@ Any disks passed through role variables must be present, the role will deliberat
 ## Example Raid Array
 ```yaml
 raid_arrays:
-  - device: /dev/md0 (raid device to create)
-    disks: (list of disks to add to the array)
+  - device: /dev/md0 (req. raid device to create)
+    disks: (req. list of disks to add to the array)
       - /dev/sdb
       - /dev/sdc
-    level: 1 (Raid level, supports anything mdadm supports)
-    filesystem: xfs (filesystem to create on the device)
-    mountpoint: /mnt/raid (where to mount it)
+    level: 1 (req. Raid level, supports anything mdadm supports)
+    layout: fX (opt. no default)
+    filesystem: xfs (opt. def xfs filesystem to create on the device)
+    filesystem_opts: (opt. default omit)
+    mountpoint: /mnt/raid (req. where to mount it)
+    mount_opts: (opt. default omit)
 ```

--- a/tasks/build_array.yml
+++ b/tasks/build_array.yml
@@ -8,29 +8,36 @@
   failed_when: rc.stat.exists == False
   with_items: "{{ array.disks }}"
 
-- set_fact:
-     device_array: "{{ array.disks + [array.device]}}"
-
-- name: Validate Current State
-  include: validate.yml
+- name: Check array state
+  include: check_array_state.yml
   with_items:
-    - "{{ device_array }}"
+    - "{{ array.disks + [ array.device] }}"
   loop_control:
     loop_var: disk
 
 - when: not skip_array
   block:
   - name: Create arrays
-    shell:  "yes | mdadm --create {{ array.device }} --level={{ array.level }} --raid-devices={{ array.disks | count }} {{ array.disks | join(' ') }}"
-    check_mode: no
+    shell:  "yes | mdadm --create {{ array.device }} --level={{ array.level }}  {% if array.layout is defined %} --layout={{ array.layout }} {% endif %} --raid-devices={{ array.disks | count }} {{ array.disks | join(' ') }}"
 
   - name: Register mdadm scan output to save md state across reboots
     command: "mdadm --detail --scan"
     register: mdadm_detail_scan
 
+  - name: Save state
+    lineinfile:
+      dest: "{{ mdadm_conf_path }}"
+      regexp: "^{{ mdadm_detail_scan.stdout_lines }}"
+      line: "{{ mdadm_detail_scan.stdout }}"
+      state: "{{ array.state | default('present') }}"
+      create: yes
+
+
+- when: array.mountpoint is defined
+  block:
   - name: Create filesystem
     filesystem:
-      fstype: "{{ array.filesystem | default(raid_default_filesystem) }}"
+      fstype: "{{ array.filesystem | default(raid_default_filesystem }}"
       opts: "{{ array.filesystem_opts | default(omit) }}"
       dev: "{{ array.device }}"
 
@@ -40,37 +47,12 @@
       state: directory
       owner: "{{ array.owner | default('root') }}"
       group: "{{ array.group | default('root') }}"
-      mode:  "{{ array.mode  | default('0644') }}"
+      mode:  "{{ array.mode  | default('0755') }}"
 
   - name: Mount device
     mount:
       name: "{{ array.mountpoint }}"
       src: "{{ array.device }}"
       state: mounted
-      opts: "{{ array.filesystem_opts | default(omit) }}"
+      opts: "{{ array.mount_opts | default(omit) }}"
       fstype: "{{ array.filesystem | default(raid_default_filesystem) }}"
-
-  - name: Append fstab
-    lineinfile:
-      dest: /etc/fstab
-      insertafter: EOF
-      line: "{{ array.device }} {{ array.mountpoint }} {{ array.filesystem | default(raid_default_filesystem) }} defaults 0 0"
-      state: "{{ array.state | default('present') }}"
-
-  - name: Ensure configs exist in mdadm.conf
-    file:
-      path: "{{ mdadm_conf_path }}"
-      state: touch
-      owner: root
-      group: root
-      mode: 0644
-
-  - name: Save state
-    lineinfile:
-      dest: "{{ mdadm_conf_path }}"
-      regexp: "^{{ mdadm_detail_scan.stdout_lines }}"
-      line: "{{ mdadm_detail_scan.stdout }}"
-      state: "{{ array.state | default('present') }}"
-
-
-


### PR DESCRIPTION
Support creating the array without mounting it.
Support `layout` option when provided.
Differentiate between `mount-opts` and `filesystem-opts`.
Don't bother editing `/etc/fstab`, the `mount:` module handles this.
Remove task to create a file, replace with `create: yes` in `lineinfile:` module.
